### PR TITLE
Fix parameter order in IS_IN_VIEWER_RECT macro

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -367,7 +367,7 @@ GLOBAL_LIST_EMPTY(chat_chuds)
 	if(coler)
 		color = coler
 
-#define IS_IN_VIEWER_RECT(turf) TURF_IN_RECTANGLE(turf, westest, eastest, northest, southest)
+#define IS_IN_VIEWER_RECT(turf) TURF_IN_RECTANGLE(turf, westest, northest, eastest, southest)
 
 /// returns a datum of players and how well they can hear the source
 /proc/get_listening(atom/source, close_range, long_range, quiet)
@@ -384,7 +384,7 @@ GLOBAL_LIST_EMPTY(chat_chuds)
 				continue dingus
 			var/westest = max(viewer_turf.x - 9, 1)
 			var/eastest = min(viewer_turf.x + 9, world.maxx)
-			var/northest = max(viewer_turf.y - 6, 1)
+			var/northest = max(viewer_turf.y - 7, 1)
 			var/southest = min(viewer_turf.y + 6, world.maxy)
 			var/list/things_in_viewer_los = view(9, viewer_turf)
 			if(SSchat.debug_chud)

--- a/code/__HELPERS/path.dm
+++ b/code/__HELPERS/path.dm
@@ -323,10 +323,14 @@
 			return
 
 /datum/pathfind/proc/checkvis(turf/destination_turf)
+	if(locate(/mob/living) in destination_turf)
+		return TRUE
 	if(destination_turf.opacity)
 		return FALSE
-	for(var/atom/iter_atom in destination_turf)
+	for(var/atom/iter_atom as anything in destination_turf)
 		if(iter_atom.opacity)
+			if(istype(iter_atom, /obj/structure/window) || istype(iter_atom, /obj/machinery/door/window))
+				continue
 			return FALSE
 	return TRUE
 

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -156,8 +156,8 @@ GLOBAL_LIST_INIT(verbal_punch_lasers, list(null,null,null,null,null,null,null,nu
 		var/turf/targetturf = get_turf(message_loc)
 		var/westest = max(ownerturf.x - 9, 1)
 		var/eastest = min(ownerturf.x + 9, world.maxx)
-		var/northest = max(ownerturf.y - 9, 1)
-		var/southest = min(ownerturf.y + 9, world.maxy)
+		var/northest = max(ownerturf.y - 7, 1)
+		var/southest = min(ownerturf.y + 6, world.maxy)
 		var/list/turfe = getline(targetturf, ownerturf)
 		var/turf/where = null
 		for(var/turf/check in turfe)


### PR DESCRIPTION
This pull request fixes the parameter order in the IS_IN_VIEWER_RECT macro. Previously, the macro had the parameters in the wrong order, which could lead to incorrect results. This PR corrects the order of the parameters to ensure the macro functions as intended.