### PR TITLE
Kimchen

### DIFF
--- a/_maps/map_files/coyote_bayou/foxybar.dmm
+++ b/_maps/map_files/coyote_bayou/foxybar.dmm
@@ -163,6 +163,12 @@
 	color = "#779999"
 	},
 /area/f13/fb/bar)
+"aEx" = (
+/obj/structure/sink/greyscale{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/f13/darkmarble,
+/area/f13/fb/bar)
 "aEB" = (
 /obj/structure/curtain{
 	color = "#c40e0e"
@@ -1653,6 +1659,12 @@
 	color = "#779999"
 	},
 /area/f13/fb/bar)
+"ifd" = (
+/obj/structure/table/abductor,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/f13/darkmarble,
+/area/f13/fb/bar)
 "ihm" = (
 /obj/effect/sound_emitter/foxybar/airconditioner,
 /turf/closed/wall/mineral/brick,
@@ -1804,6 +1816,13 @@
 /area/f13/fb/bar)
 "iYl" = (
 /turf/open/floor/carpet/royalblack,
+/area/f13/fb/bar)
+"jdE" = (
+/obj/structure/sink/greyscale{
+	dir = 8;
+	pixel_x = -13
+	},
+/turf/open/floor/plasteel/f13/darkmarble,
 /area/f13/fb/bar)
 "jiT" = (
 /obj/structure/sign/painting/library{
@@ -2493,9 +2512,10 @@
 	},
 /area/f13/fb/bar)
 "oNR" = (
-/obj/structure/table/abductor,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife/butcher,
+/obj/structure/closet/crate/bin/trashbin{
+	pixel_x = 12;
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel/f13/darkmarble,
 /area/f13/fb/bar)
 "oOK" = (
@@ -2682,6 +2702,10 @@
 	color = "#993311";
 	alpha = 10
 	},
+/obj/structure/table/abductor,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
 /turf/open/floor/plasteel/f13/darkmarble,
 /area/f13/fb/bar)
 "qms" = (
@@ -2776,6 +2800,15 @@
 /turf/open/floor/wood_fancy{
 	color = "#779999"
 	},
+/area/f13/fb/bar)
+"qGK" = (
+/obj/machinery/light/floor{
+	light_color = "#993311";
+	color = "#993311";
+	alpha = 10
+	},
+/obj/machinery/microwave/stove,
+/turf/open/floor/plasteel/f13/darkmarble,
 /area/f13/fb/bar)
 "qKK" = (
 /obj/effect/decal/cleanable/glitter/white{
@@ -11244,7 +11277,7 @@ dLD
 tFy
 lvh
 pXC
-xAW
+sbf
 tFy
 tFy
 hHE
@@ -11358,7 +11391,7 @@ llj
 hov
 tFy
 sTj
-rWC
+jdE
 rWC
 rWC
 rWC
@@ -11591,11 +11624,11 @@ gGC
 ghq
 tPi
 tFy
-oNR
+sbf
 rWC
-rWC
-rWC
-qlV
+ifd
+xAW
+qGK
 rWC
 rWC
 jnG
@@ -11710,9 +11743,9 @@ tFy
 tFy
 gzb
 rWC
-rWC
+oNR
 qlV
-rWC
+aEx
 rWC
 rWC
 jYx

--- a/code/controllers/subsystem/processing/food_printer.dm
+++ b/code/controllers/subsystem/processing/food_printer.dm
@@ -49,7 +49,7 @@ PROCESSING_SUBSYSTEM_DEF(food_printer)
 	foods = list()
 	for(var/thing in subtypesof(/obj/item))
 		var/obj/item/I = thing
-		if(!initial(I.is_food))
+		if(!initial(I.is_food) && !initial(I.is_kitchenware))
 			continue
 		var/datum/food_menu_entry/entry = new /datum/food_menu_entry(I)
 		entry.disambiguator = "[disambiguator]"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -253,7 +253,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	var/is_icecream = FALSE
 	var/is_sushi = FALSE
 	var/is_insect = FALSE
-
+	var/is_kitchenware = FALSE
 
 
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -253,7 +253,7 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	var/is_icecream = FALSE
 	var/is_sushi = FALSE
 	var/is_insect = FALSE
-	var/is_kitchenware = FALSE
+	var/is_kitchenware = FALSE //For things that aren't quite food but are still kitchen/food related and deserve to be printed from the foodfops
 
 
 

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -14,6 +14,7 @@
 	lefthand_file = 'icons/fallout/onmob/tools/kitchen_lefthand.dmi'
 	righthand_file = 'icons/fallout/onmob/tools/kitchen_righthand.dmi'
 	slot_flags = INV_SLOTBIT_BELT | INV_SLOTBIT_BACK
+	is_kitchenware = TRUE
 
 /obj/item/kitchen/fork
 	name = "fork"

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -284,6 +284,7 @@
 	flags_1 = CONDUCT_1
 	custom_materials = list(/datum/material/iron=3000)
 	var/max_items = 7
+	is_kitchenware = TRUE
 
 /obj/item/storage/bag/tray/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -774,6 +774,7 @@
 	foldable = null
 	/// A list of all available papersack reskins
 	var/list/papersack_designs = list()
+	is_kitchenware = TRUE
 
 /obj/item/storage/box/papersack/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -346,6 +346,7 @@ GLOBAL_LIST_EMPTY(rubber_toolbox_icons)
 	icon_state = "lunchbox_rainbow"
 	desc = "A little lunchbox. This one is the colors of the rainbow!"
 	attack_verb = list("lunched")
+	is_kitchenware = TRUE
 
 /obj/item/storage/bag/plants/lunchbox/hearts
 	name = "heart lunchbox"

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -304,6 +304,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	var/fill_icon = 'icons/obj/food/soupsalad.dmi'
 	var/fill_state = "fullbowl"
+	is_kitchenware = TRUE
 
 /obj/item/reagent_containers/glass/bowl/attackby(obj/item/I,mob/user, params)
 	if(istype(I, /obj/item/reagent_containers/food/snacks))

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -129,6 +129,7 @@
 	custom_materials = list(/datum/material/glass=500)
 	possible_transfer_amounts = list(5,10,15,20,25,30,50,60)
 	container_flags = PH_WEAK|APTFT_ALTCLICK|APTFT_VERB
+	is_kitchenware = TRUE
 
 /obj/item/reagent_containers/glass/beaker/Initialize()
 	. = ..()
@@ -271,12 +272,15 @@
 
 /obj/item/reagent_containers/glass/beaker/cryoxadone
 	list_reagents = list(/datum/reagent/medicine/cryoxadone = 30)
+	is_kitchenware = FALSE
 
 /obj/item/reagent_containers/glass/beaker/sulphuric
 	list_reagents = list(/datum/reagent/toxin/acid = 50)
+	is_kitchenware = FALSE
 
 /obj/item/reagent_containers/glass/beaker/slime
 	list_reagents = list(/datum/reagent/toxin/slimejelly = 50)
+	is_kitchenware = FALSE
 
 /obj/item/reagent_containers/glass/beaker/large/styptic
 	name = "styptic reserve tank"
@@ -296,6 +300,7 @@
 
 /obj/item/reagent_containers/glass/beaker/synthflesh
 	list_reagents = list(/datum/reagent/medicine/synthflesh = 50)
+	is_kitchenware = FALSE
 
 /obj/item/reagent_containers/glass/beaker/big_red/full
 	list_reagents = list(/datum/reagent/consumable/big_red = 60)

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -418,6 +418,7 @@ Burning extracts:
 	force = 15
 	throwforce = 15
 	damtype = BRUTE
+	is_kitchenware = FALSE
 
 /obj/item/kitchen/knife/rainbowknife/afterattack(atom/O, mob/user, proximity)
 	if(proximity && istype(O, /mob/living))

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -128,6 +128,7 @@
 	throwforce = 10
 	w_class = WEIGHT_CLASS_NORMAL
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	is_kitchenware = FALSE
 
 /obj/item/kitchen/knife/envy/afterattack(atom/movable/AM, mob/living/carbon/human/user, proximity)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
This PR adds a number of misc items that are kitchen/cooking related to the foodfops (such as beakers, knives, lunchbags, lunchboxes, rolling pins, ect), since it already has various bar related items. It also makes the kitchen a little less barren and more feature complete, by adding 2 sink, a garbage can, and a couple counters with a second stove in the middle of the dreaded empty space

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: "Kitchenware" items are now printable using the foodfox
add: Sinks, garbage cans, extra counters and extra stoves added to the kitchen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
