### PR TITLE
Maid Café

### DIFF
--- a/_maps/templates/splurt_templates/hilbertshotel_templates/maidcafe.dmm
+++ b/_maps/templates/splurt_templates/hilbertshotel_templates/maidcafe.dmm
@@ -68,11 +68,11 @@
 /area/hilbertshotel)
 "kC" = (
 /obj/structure/window/spawner/east,
+/obj/structure/table/wood/settler,
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = -5
 	},
-/obj/structure/table/wood/settler,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/hilbertshotel)
 "kQ" = (
@@ -96,11 +96,11 @@
 /area/hilbertshotel)
 "ni" = (
 /obj/structure/window/spawner/east,
-/obj/structure/table/wood/settler,
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = -5
 	},
+/obj/structure/table/wood/settler,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/hilbertshotel)
 "nj" = (
@@ -128,7 +128,9 @@
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "qn" = (
-/obj/structure/food_printer,
+/obj/structure/food_printer{
+	name = "GekkerTec FoodFox 2000 - Private"
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/hilbertshotel)
 "qH" = (
@@ -656,10 +658,10 @@ ZE
 (8,1,1) = {"
 ZE
 tl
-kC
+ni
 Mr
 Pz
-ni
+kC
 Mr
 Wg
 Wg

--- a/_maps/templates/splurt_templates/hilbertshotel_templates/maidcafe.dmm
+++ b/_maps/templates/splurt_templates/hilbertshotel_templates/maidcafe.dmm
@@ -1,0 +1,817 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"bg" = (
+/obj/machinery/telecomms/relay/preset/auto,
+/turf/open/indestructible/ground/outside/desert,
+/area/hilbertshotel)
+"cK" = (
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"dy" = (
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"dR" = (
+/obj/structure/table/glass,
+/obj/structure/window/spawner/east,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"ee" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"fo" = (
+/obj/structure/table/glass,
+/obj/machinery/door/window/left/directional/east,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"hi" = (
+/obj/structure/window/spawner/north,
+/obj/structure/chair/middle,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"jj" = (
+/obj/structure/simple_door/room{
+	name = "Bathroom"
+	},
+/obj/item/lock_bolt{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile,
+/area/hilbertshotel)
+"kp" = (
+/obj/structure/chair/left{
+	dir = 1;
+	plane = -2;
+	pixel_y = -4
+	},
+/obj/structure/window/spawner,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"kr" = (
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"kB" = (
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/obj/machinery/light,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"kC" = (
+/obj/structure/window/spawner/east,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = -5
+	},
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"kQ" = (
+/turf/closed/indestructible/hoteldoor{
+	icon = 'icons/obj/doors/puzzledoor/default.dmi';
+	icon_state = "door_closed"
+	},
+/area/hilbertshotel)
+"li" = (
+/obj/machinery/vending/lewdpillz,
+/turf/open/floor/plasteel/dark,
+/area/hilbertshotel)
+"lS" = (
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"ni" = (
+/obj/structure/window/spawner/east,
+/obj/structure/table/wood/settler,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = -5
+	},
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"nj" = (
+/obj/structure/table/glass,
+/obj/machinery/door/window/left/directional/south,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"nQ" = (
+/obj/structure/chair/wood/wings{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"oH" = (
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"pr" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/indestructible/hoteltile,
+/area/hilbertshotel)
+"qn" = (
+/obj/structure/food_printer,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"qH" = (
+/obj/structure/table/glass,
+/obj/machinery/processor/chopping_block,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"qQ" = (
+/obj/structure/window/spawner,
+/obj/structure/chair/left{
+	dir = 1;
+	plane = -2;
+	pixel_y = -4
+	},
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"rY" = (
+/obj/structure/simple_door/room{
+	name = "kitchen"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"sm" = (
+/obj/structure/window/spawner,
+/obj/structure/chair/middle{
+	dir = 1;
+	plane = -2;
+	pixel_y = -4
+	},
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"sU" = (
+/obj/structure/sink/cupboard,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/hilbertshotel)
+"sY" = (
+/obj/structure/table/glass,
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner/west,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"te" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood_mosaic,
+/area/hilbertshotel)
+"tl" = (
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner/east,
+/obj/structure/chair/left,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"tx" = (
+/obj/structure/table/glass,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/rollingpin,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
+/obj/item/storage/bag/tray,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"up" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"ut" = (
+/obj/structure/table/glass,
+/obj/structure/window/spawner,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"vU" = (
+/obj/structure/window/spawner/north,
+/obj/structure/chair/wood/wings,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"vW" = (
+/obj/structure/table/glass,
+/obj/structure/window/spawner/north,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"wg" = (
+/obj/machinery/jukebox,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"wB" = (
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/pen/fountain,
+/obj/structure/table/wood/settler,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"xI" = (
+/obj/structure/rack/shelf_wood,
+/obj/item/reagent_containers/glass/bucket/plastic,
+/obj/item/mop,
+/turf/open/floor/plasteel/dark,
+/area/hilbertshotel)
+"yz" = (
+/obj/machinery/microwave/stove,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"yO" = (
+/obj/structure/window/spawner,
+/obj/structure/chair/wood/wings{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"AI" = (
+/turf/open/floor/wood_mosaic,
+/area/hilbertshotel)
+"CL" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"CQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/bar,
+/area/hilbertshotel)
+"DV" = (
+/obj/machinery/vending/kink{
+	shut_up = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/hilbertshotel)
+"EI" = (
+/obj/structure/fermenting_barrel,
+/obj/machinery/light,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"Fz" = (
+/obj/structure/table/glass,
+/obj/machinery/door/window/right/directional/south,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"FA" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"FU" = (
+/obj/structure/closet/crate/bin/trashbin,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/bar,
+/area/hilbertshotel)
+"GV" = (
+/turf/open/indestructible/hoteltile,
+/area/hilbertshotel)
+"Hx" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"Hy" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"Ik" = (
+/obj/structure/table/wood,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/obj/item/soap/deluxe,
+/turf/open/floor/plasteel/dark,
+/area/hilbertshotel)
+"Ji" = (
+/obj/structure/simple_door/room{
+	name = "janitors closet"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hilbertshotel)
+"Mr" = (
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner,
+/obj/structure/chair/right{
+	dir = 1;
+	plane = -2;
+	pixel_y = -4
+	},
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"Mz" = (
+/obj/structure/table/glass,
+/obj/structure/window/spawner/north,
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"OA" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"Pz" = (
+/obj/structure/window/spawner/east,
+/obj/structure/window/spawner/north,
+/obj/structure/chair/left,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"PG" = (
+/obj/machinery/vending/boozeomat{
+	shut_up = 1
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"QC" = (
+/obj/structure/table/wood/settler,
+/obj/item/candle/infinite{
+	pixel_y = 14
+	},
+/turf/open/floor/wood_mosaic,
+/area/hilbertshotel)
+"QE" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"QJ" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/indestructible/hoteltile,
+/area/hilbertshotel)
+"RL" = (
+/obj/structure/window/spawner/north,
+/obj/structure/chair/right,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"Sa" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hilbertshotel)
+"SW" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"SX" = (
+/obj/machinery/light,
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"Tk" = (
+/obj/structure/closet/cabinet/anchored,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/accessory/maidskirt,
+/obj/item/clothing/accessory/maidskirt,
+/obj/item/clothing/accessory/maidskirt,
+/obj/item/clothing/accessory/maidskirt,
+/obj/item/clothing/accessory/maidskirt,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/suit/armor/outfit/overalls/sexymaid,
+/obj/item/clothing/suit/armor/outfit/overalls/sexymaid,
+/obj/item/clothing/suit/armor/outfit/overalls/sexymaid,
+/obj/item/clothing/suit/armor/outfit/overalls/sexymaid,
+/obj/item/clothing/suit/armor/outfit/overalls/sexymaid,
+/obj/item/clothing/under/costume/maid,
+/obj/item/clothing/under/costume/maid,
+/obj/item/clothing/under/costume/maid,
+/obj/item/clothing/under/costume/maid,
+/obj/item/clothing/under/costume/maid,
+/obj/item/clothing/under/janimaid,
+/obj/item/clothing/under/janimaid,
+/obj/item/clothing/under/janimaid,
+/obj/item/clothing/under/janimaid,
+/obj/item/clothing/under/janimaid,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/skyrat/maid,
+/obj/item/clothing/under/skyrat/maid,
+/obj/item/clothing/under/skyrat/maid,
+/obj/item/clothing/under/skyrat/maid,
+/obj/item/clothing/under/skyrat/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/obj/item/clothing/head/maid,
+/turf/open/floor/plasteel/dark,
+/area/hilbertshotel)
+"Tt" = (
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"Tx" = (
+/obj/item/lock_bolt{
+	dir = 4
+	},
+/obj/structure/simple_door/room{
+	name = "Private room"
+	},
+/turf/open/indestructible/hoteltile,
+/area/hilbertshotel)
+"TA" = (
+/turf/open/floor/plasteel/dark,
+/area/hilbertshotel)
+"UR" = (
+/obj/structure/window/spawner/north,
+/obj/structure/window/spawner/east,
+/obj/machinery/smartfridge/food,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"We" = (
+/obj/structure/table/glass,
+/obj/structure/window/spawner/east,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"Wg" = (
+/turf/open/floor/plasteel/bar,
+/area/hilbertshotel)
+"WO" = (
+/obj/machinery/door/window/left/directional/east,
+/turf/open/floor/wood_fancy/wood_fancy_dark,
+/area/hilbertshotel)
+"Xr" = (
+/obj/structure/mirror{
+	pixel_y = 31
+	},
+/obj/structure/sink/cupboard,
+/turf/open/indestructible/hoteltile,
+/area/hilbertshotel)
+"Zn" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"ZE" = (
+/turf/closed/wall/mineral/brick,
+/area/hilbertshotel)
+
+(1,1,1) = {"
+bg
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+kQ
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+"}
+(2,1,1) = {"
+ZE
+vU
+ee
+yO
+vU
+ee
+yO
+FU
+Wg
+lS
+oH
+wg
+OA
+Tt
+kr
+ZE
+"}
+(3,1,1) = {"
+ZE
+vU
+dy
+yO
+vU
+dy
+yO
+Wg
+Wg
+dy
+nQ
+oH
+oH
+oH
+kr
+ZE
+"}
+(4,1,1) = {"
+ZE
+oH
+oH
+oH
+oH
+oH
+oH
+Wg
+Wg
+dy
+nQ
+oH
+oH
+oH
+kB
+ZE
+"}
+(5,1,1) = {"
+ZE
+oH
+oH
+oH
+oH
+oH
+oH
+Wg
+Wg
+dy
+oH
+oH
+oH
+oH
+wB
+ZE
+"}
+(6,1,1) = {"
+ZE
+RL
+dy
+kp
+RL
+dy
+qQ
+Wg
+Wg
+ZE
+dR
+fo
+WO
+fo
+We
+ZE
+"}
+(7,1,1) = {"
+ZE
+hi
+dy
+sm
+hi
+dy
+sm
+Wg
+Wg
+Mz
+Hx
+Zn
+Zn
+Zn
+PG
+ZE
+"}
+(8,1,1) = {"
+ZE
+tl
+kC
+Mr
+Pz
+ni
+Mr
+Wg
+Wg
+UR
+Zn
+up
+CL
+Zn
+EI
+ZE
+"}
+(9,1,1) = {"
+ZE
+Wg
+Wg
+Wg
+Wg
+Wg
+Wg
+Wg
+Wg
+nj
+Zn
+CL
+CL
+Zn
+tx
+ZE
+"}
+(10,1,1) = {"
+ZE
+ZE
+jj
+ZE
+ZE
+Tx
+ZE
+Wg
+Wg
+ut
+Zn
+qH
+yz
+Zn
+QE
+ZE
+"}
+(11,1,1) = {"
+ZE
+QJ
+GV
+ZE
+QC
+AI
+ZE
+Wg
+Wg
+Fz
+Zn
+yz
+qH
+Zn
+SW
+ZE
+"}
+(12,1,1) = {"
+ZE
+Xr
+pr
+ZE
+te
+AI
+ZE
+Wg
+Wg
+sY
+Zn
+CL
+CL
+Zn
+SW
+ZE
+"}
+(13,1,1) = {"
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+CQ
+Wg
+vW
+Zn
+CL
+CL
+Zn
+cK
+ZE
+"}
+(14,1,1) = {"
+ZE
+xI
+Ik
+DV
+li
+sU
+ZE
+Wg
+Wg
+ZE
+Hy
+Zn
+Zn
+Zn
+SX
+ZE
+"}
+(15,1,1) = {"
+ZE
+Tk
+TA
+Sa
+TA
+TA
+Ji
+Wg
+Wg
+rY
+FA
+Zn
+Zn
+Zn
+qn
+ZE
+"}
+(16,1,1) = {"
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+ZE
+"}

--- a/_maps/templates/splurt_templates/hilbertshotel_templates/maidcafe.dmm
+++ b/_maps/templates/splurt_templates/hilbertshotel_templates/maidcafe.dmm
@@ -68,11 +68,11 @@
 /area/hilbertshotel)
 "kC" = (
 /obj/structure/window/spawner/east,
-/obj/structure/table/wood/settler,
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = -5
 	},
+/obj/structure/table/wood/settler,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/hilbertshotel)
 "kQ" = (
@@ -96,11 +96,11 @@
 /area/hilbertshotel)
 "ni" = (
 /obj/structure/window/spawner/east,
+/obj/structure/table/wood/settler,
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = -5
 	},
-/obj/structure/table/wood/settler,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/hilbertshotel)
 "nj" = (
@@ -151,6 +151,7 @@
 /obj/structure/simple_door/room{
 	name = "kitchen"
 	},
+/obj/item/lock_bolt,
 /turf/open/floor/plasteel/cafeteria,
 /area/hilbertshotel)
 "sm" = (
@@ -658,10 +659,10 @@ ZE
 (8,1,1) = {"
 ZE
 tl
-ni
+kC
 Mr
 Pz
-kC
+ni
 Mr
 Wg
 Wg

--- a/_maps/templates/splurt_templates/hilbertshotel_templates/maidcafe.dmm
+++ b/_maps/templates/splurt_templates/hilbertshotel_templates/maidcafe.dmm
@@ -68,11 +68,11 @@
 /area/hilbertshotel)
 "kC" = (
 /obj/structure/window/spawner/east,
+/obj/structure/table/wood/settler,
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = -5
 	},
-/obj/structure/table/wood/settler,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/hilbertshotel)
 "kQ" = (
@@ -96,11 +96,11 @@
 /area/hilbertshotel)
 "ni" = (
 /obj/structure/window/spawner/east,
-/obj/structure/table/wood/settler,
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = -5
 	},
+/obj/structure/table/wood/settler,
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/hilbertshotel)
 "nj" = (
@@ -289,6 +289,10 @@
 "EI" = (
 /obj/structure/fermenting_barrel,
 /obj/machinery/light,
+/turf/open/floor/plasteel/cafeteria,
+/area/hilbertshotel)
+"Fn" = (
+/obj/structure/closet/secure_closet/freezer/meat/open,
 /turf/open/floor/plasteel/cafeteria,
 /area/hilbertshotel)
 "Fz" = (
@@ -659,10 +663,10 @@ ZE
 (8,1,1) = {"
 ZE
 tl
-kC
+ni
 Mr
 Pz
-ni
+kC
 Mr
 Wg
 Wg
@@ -725,7 +729,7 @@ Zn
 yz
 qH
 Zn
-SW
+Fn
 ZE
 "}
 (12,1,1) = {"

--- a/modular_splurt/code/modules/hilbertshotel/hilbertshotel.dm
+++ b/modular_splurt/code/modules/hilbertshotel/hilbertshotel.dm
@@ -29,6 +29,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 	"Chess",
 	"Glade-One",
 	"Wildsauna-One",
+	"Maid cafe"
 	)
 	var/datum/map_template/hilbertshotel/apartment/one/hilberts_hotel_rooms_apartment_one
 	var/datum/map_template/hilbertshotel/apartment/two/hilberts_hotel_rooms_apartment_two
@@ -48,6 +49,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 	var/datum/map_template/hilbertshotel/apartment/chessboard/thechess
 	var/datum/map_template/hilbertshotel/apartment/glade_one/glade_one
 	var/datum/map_template/hilbertshotel/apartment/wildsauna_one/wildsauna_one
+	var/datum/map_template/hilbertshotel/apartment/maidcafe/maidcafe
 	//FB Maps End
 	var/datum/map_template/hilbertshotel/hotelRoomTemp
 	var/datum/map_template/hilbertshotel/empty/hotelRoomTempEmpty
@@ -88,6 +90,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 	thechess = new()
 	glade_one = new()
 	wildsauna_one = new()
+	maidcafe = new()
 
 /obj/hilbertshotel/proc/getMapTemplate(roomType) // To load a map and remove it's atoms
 	switch(roomType)
@@ -108,6 +111,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 		if("Chess") return thechess
 		if("Glade-One") return glade_one
 		if("Wildsauna-One") return wildsauna_one
+		if("Maid cafe") return maidcafe
 		if("Mystery Room") return hotelRoomTempLore
 		
 	return hotelRoomTemp // Default to Hotel Room if no match is found
@@ -141,6 +145,7 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 			if("Chess") mapTemplate = thechess
 			if("Glade-One") mapTemplate = glade_one
 			if("Wildsauna-One") mapTemplate = wildsauna_one
+			if("Maid cafe") mapTemplate = maidcafe
 
 	if(!mapTemplate)
 		mapTemplate = hotelRoomTemp //Default Hotel Room
@@ -236,6 +241,11 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 /datum/map_template/hilbertshotel/apartment/wildsauna_one
 	name = "Wildsauna-One"
 	mappath = '_maps/templates/splurt_templates/hilbertshotel_templates/wildsauna_1.dmm'
+
+/datum/map_template/hilbertshotel/apartment/maidcafe
+	name = "Maid cafe"
+	mappath = '_maps/templates/splurt_templates/hilbertshotel_templates/maidcafe.dmm'
+
 
 /obj/hilbertshotel/Destroy()
 	ejectRooms()


### PR DESCRIPTION
## About The Pull Request
Adds a Maid Café preset for the hilbert's hotel.
Features include:
Reception, for welcoming guests (and an arcade machine to keep the staff occupied because no one will care about this stupid thing)!
Kitchen, for all sorts of foods and drinks (includes it's own foodfops)!
Public booths, for family friendly activites!
Private booth, for family making activities (Candlelit, and with a bolt)!
Closet for dressing, maid uniforms, kink vending machine and kink pill vending machine (for spiking drinks upon customer's request :3 ) and cleaning supplies!
Looks like this:
![maidcafe](https://github.com/user-attachments/assets/427663bf-8676-4a6f-a20f-16e470ae6544)



## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Maid café preset for Hilbert's hotel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
