### PR TITLE
Global foodprinter

### DIFF
--- a/_maps/map_files/coyote_bayou/foxybar.dmm
+++ b/_maps/map_files/coyote_bayou/foxybar.dmm
@@ -2850,6 +2850,10 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
 	},
+/obj/structure/food_printer{
+	is_global = 1;
+	name = "GekkerTec FoodFox 2000 Global Food Delivery Service"
+	},
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},

--- a/_maps/templates/splurt_templates/hilbertshotel_templates/maidcafe.dmm
+++ b/_maps/templates/splurt_templates/hilbertshotel_templates/maidcafe.dmm
@@ -128,9 +128,7 @@
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "qn" = (
-/obj/structure/food_printer{
-	name = "GekkerTec FoodFox 2000 - Private"
-	},
+/obj/structure/food_printer,
 /turf/open/floor/plasteel/cafeteria,
 /area/hilbertshotel)
 "qH" = (

--- a/code/game/machinery/food_printer_2000.dm
+++ b/code/game/machinery/food_printer_2000.dm
@@ -17,7 +17,7 @@
 	var/target_beacon
 	var/last_new_beacon = 0
 	var/list/usage_log = list()
-
+	var/is_global = FALSE
 	var/obj/item/pda/moviefone
 	var/list/calls = list()
 	var/list/orders_in_progress = list()
@@ -25,7 +25,8 @@
 /obj/structure/food_printer/Initialize()
 	. = ..()
 	menu = SSfood_printer.food_menu
-	GeneratePDA()
+	if(is_global)
+		GeneratePDA()
 	new /obj/item/foodprinter_output_beacon(GetNearestTable(src, 2, TRUE))
 	sl_1 = new /datum/looping_sound/foodprinter_1(list(src), FALSE)
 	sl_2 = new /datum/looping_sound/foodprinter_2(list(src), FALSE)

--- a/code/game/machinery/food_printer_2000.dm
+++ b/code/game/machinery/food_printer_2000.dm
@@ -17,7 +17,7 @@
 	var/target_beacon
 	var/last_new_beacon = 0
 	var/list/usage_log = list()
-	var/is_global = FALSE
+	var/is_global = FALSE //If this is false, do not show up on PDAs
 	var/obj/item/pda/moviefone
 	var/list/calls = list()
 	var/list/orders_in_progress = list()


### PR DESCRIPTION
## About The Pull Request
Adds a new variable to the foodfops, the is_global, which is false by default. If this is false, the foodfops won't be registered on PDAs. Instead, also adds a foodfops to the tcoms room at foxybar ground floor.
But why?
A) So that the PDA won't be overcrowded, if, say, someone were to make 20 hilbert rooms containing foodfopses
B) So that the public foodfops won't be occupied by private orders, which may inconvinience those working in the kitchen, and also present a privacy risk as the orders and the beacons associated with said orders are blurted out loud with an attention grabbing sound effect.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Tweaked the foodfox to only have a single entry in the PDA, and also for orders to remain private.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
