### PR TITLE
Pixelshift adjustments

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -435,8 +435,8 @@
 #define OFFSET_MUTPARTS "mutantparts"
 
 //MINOR TWEAKS/MISC
-#define PIXELSHIFT_MIN		-12	//more shifted you can be
-#define PIXELSHIFT_MAX		12	//most shifted you can be
+#define PIXELSHIFT_MIN		-32	//more shifted you can be
+#define PIXELSHIFT_MAX		32	//most shifted you can be
 #define AGE_MIN				21	//youngest a character can be //FB edit, 21 to fit the theme
 #define AGE_MAX				999999999	// If I see one fucking loli dragon I am fucking exploding you people.
 #define WIZARD_AGE_MIN		30	//youngest a wizard can be


### PR DESCRIPTION
## About The Pull Request
Adjusts pixel shift to be adjustable by a whole tile.
Why? Because enourmous snake ass blocks everything south, and this is a CB/FB2 specific issue, that other serves handle by setting the origo of a character at 0,0 instead of in the middle of the character. At the same time, it is a neat feature that works great for mediumly big characters, so instead of messing with it directly, let's make it optional by increasing the range that people can manually adjust their character's pixel shift.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Makes it so that pixel shift allows for up to a whole tile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
